### PR TITLE
Add request version supporting

### DIFF
--- a/modules/XMLDocuments/helpers/xmlGenerator.js
+++ b/modules/XMLDocuments/helpers/xmlGenerator.js
@@ -91,6 +91,9 @@ const filterProduct = (product, VATTaxList) => {
 export const updateTaxesWithValidVAT = (taxes, VATTaxList) =>
   taxes.filter((tax) => isTaxValid(tax, VATTaxList));
 
+export const addVersionInEntities = (entities, version) =>
+  entities.map((entity) => ({ ...entity, version }));
+
 export const updateProductsWithValidTaxes = (products, VATTaxList) => {
   return products.map((product) => filterProduct(product, VATTaxList));
 };

--- a/modules/XMLDocuments/index.spec.js
+++ b/modules/XMLDocuments/index.spec.js
@@ -431,8 +431,8 @@ describe("XMLDocuments", () => {
             "    </TAXES>\n" +
             "  </ZREPREALIZ>\n" +
             "  <ZREPBODY>\n" +
-            "    <SERVICEINPUT>0.00</SERVICEINPUT>\n" +
-            "    <SERVICEOUTPUT>0.00</SERVICEOUTPUT>\n" +
+            "    <SERVICEINPUT>10.00</SERVICEINPUT>\n" +
+            "    <SERVICEOUTPUT>20.00</SERVICEOUTPUT>\n" +
             "  </ZREPBODY>\n" +
             "</ZREP>",
         );

--- a/modules/XMLDocuments/mock/data.js
+++ b/modules/XMLDocuments/mock/data.js
@@ -193,8 +193,8 @@ export const zReportData = {
     ],
   },
   return: null,
-  serviceInput: 0,
-  serviceOutput: 0,
+  serviceInput: { sum: 1000 },
+  serviceOutput: { sum: 2000 },
   dateTime: "2024-04-18T15:16:17",
   uid: "11111111-1111-1111-1111-111111111111",
   cashboxData: {


### PR DESCRIPTION
Механізм працює так: `requestVersion` — це числовий параметр, який перевіряється в `poster-prro-kit`.
Якщо його значення не менше за поточну версію, відповідні зміни застосовуються.
Тобто, якщо вам потрібно щось оновити в `poster-prro-kit`, ви перевіряєте `requestVersion`,
щоб переконатися, що оновлення дозволене.

Приклад:
```
export const getVersionSpecificFields = (requestVersion, fields) =>
  requestVersion >= 2 ? fields : {};
```
Використання:
```
getVersionSpecificFields(2, { TURNOVERDISCOUNT, SOURCESUM });

return {
   $: getRowNum(index),
   TYPE,
   NAME,
   LETTER,
   PRC,
   TURNOVER,
   ...getVersionSpecificFields(requestVersion, { TURNOVERDISCOUNT, SOURCESUM }),
   SUM,
};
```