### PR TITLE
Refactoring receipt generator module

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ import {
   generateHtmlServiceTransactionReceipt,
   generateHtmlFiscalReceipt,
   generateHTMLXZReport,
+  getPreparedDataForPrintReceipt,
 } from "./modules/receiptGenerator/index.js";
 import {
   getReceiptOfflineModeRequestData,
@@ -60,6 +61,7 @@ export {
   generateHtmlServiceTransactionReceipt,
   generateHtmlFiscalReceipt,
   generateHTMLXZReport,
+  getPreparedDataForPrintReceipt,
   getReceiptOfflineModeRequestData,
   getTransactionOfflineModeRequestData,
   getZReportOfflineModeRequestData,

--- a/modules/receiptGenerator/helpers/receiptData.js
+++ b/modules/receiptGenerator/helpers/receiptData.js
@@ -61,11 +61,6 @@ const getPaymentsData = (data) => {
     cash: cashSum
       ? formatToFixedDecimal(convertKopecksToGrivnas(cashSum))
       : null,
-    taxes: [...data.taxes].sort(sortByProgram).map((tax) => ({
-      name: expandedTaxesName(tax),
-      value: getTaxSum(tax),
-      program: tax.program,
-    })),
   };
 };
 
@@ -144,7 +139,7 @@ const getSstData = ({ sstData, type }) => {
   };
 };
 
-export const preparedDataForPrintReceipt = (data) => ({
+export const prepareDataForPrintReceipt = (data) => ({
   qrOptions: data.qrOptions,
   fiscalId: data.fiscalId,
   dateTime: getDateTime({ date: data.dateTime }),

--- a/modules/receiptGenerator/helpers/receiptData.js
+++ b/modules/receiptGenerator/helpers/receiptData.js
@@ -48,18 +48,29 @@ const productsSum = ({ products }) => {
   }, 0);
 };
 
-const getTaxesAndPaymentsData = (data) => {
+const getPaymentsData = (data) => {
   const cardSum = data.payments.find(findCardPayment)?.sum;
   const cashSum = data.payments.find(findCashPayment)?.sum;
 
   return {
     productsSum: productsSum(data),
+    total: getReceiptTotal(data) - getRoundSum(data),
     card: cardSum
       ? formatToFixedDecimal(convertKopecksToGrivnas(cardSum))
       : null,
     cash: cashSum
       ? formatToFixedDecimal(convertKopecksToGrivnas(cashSum))
       : null,
+    taxes: [...data.taxes].sort(sortByProgram).map((tax) => ({
+      name: expandedTaxesName(tax),
+      value: getTaxSum(tax),
+      program: tax.program,
+    })),
+  };
+};
+
+const getTaxesData = (data) => {
+  return {
     taxes: [...data.taxes].sort(sortByProgram).map((tax) => ({
       name: expandedTaxesName(tax),
       value: getTaxSum(tax),
@@ -133,7 +144,7 @@ const getSstData = ({ sstData, type }) => {
   };
 };
 
-export const prepareDataForPrintReceipt = (data) => ({
+export const preparedDataForPrintReceipt = (data) => ({
   qrOptions: data.qrOptions,
   fiscalId: data.fiscalId,
   dateTime: getDateTime({ date: data.dateTime }),
@@ -154,7 +165,8 @@ export const prepareDataForPrintReceipt = (data) => ({
     taxPrograms: product.taxPrograms,
     discount: product.discount,
   })),
-  taxesAndPaymentsData: getTaxesAndPaymentsData(data),
+  paymentsData: getPaymentsData(data),
+  taxesData: getTaxesData(data),
   roundData: getRoundReceiptData(data),
   sstData: getSstData(data),
   footerData: getFooterData({

--- a/modules/receiptGenerator/index.js
+++ b/modules/receiptGenerator/index.js
@@ -1,6 +1,6 @@
 import receipt from "receipt";
 import defaultReceiptConfig from "./config/receipt.js";
-import { prepareDataForPrintReceipt } from "./helpers/receiptData.js";
+import { preparedDataForPrintReceipt } from "./helpers/receiptData.js";
 import { initReceipt } from "./helpers/receipt.js";
 import getFiscalReceiptData from "./templateData/getFiscalReceiptData.js";
 import renderFiscalReceipt from "./templateBlocks/htmlFiscalReceipt.js";
@@ -9,7 +9,7 @@ import getXZReportData from "./templateData/getXZReportData.js";
 import renderXZReport from "./templateBlocks/htmlXZReport.js";
 
 const generateHtmlFiscalReceipt = (data) => {
-  const receiptData = prepareDataForPrintReceipt(data);
+  const receiptData = preparedDataForPrintReceipt(data);
   const fiscalReceiptData = getFiscalReceiptData(receiptData, true);
   return renderFiscalReceipt(fiscalReceiptData);
 };
@@ -24,7 +24,7 @@ const generateHtmlServiceTransactionReceipt = (data) => {
 
 const generateTextFiscalReceipt = (data) => {
   initReceipt(data.receiptConfig || defaultReceiptConfig);
-  const receiptData = prepareDataForPrintReceipt(data);
+  const receiptData = preparedDataForPrintReceipt(data);
   const fiscalReceiptData = getFiscalReceiptData(receiptData);
   return receipt.create(fiscalReceiptData);
 };
@@ -46,6 +46,9 @@ const generateHTMLXZReport = (data) => {
   return renderXZReport(xzReportData);
 };
 
+const getPreparedDataForPrintReceipt = (data) =>
+  preparedDataForPrintReceipt(data);
+
 export {
   generateTextFiscalReceipt,
   generateHtmlFiscalReceipt,
@@ -53,4 +56,5 @@ export {
   generateHtmlServiceTransactionReceipt,
   generateXZReport,
   generateHTMLXZReport,
+  getPreparedDataForPrintReceipt,
 };

--- a/modules/receiptGenerator/index.js
+++ b/modules/receiptGenerator/index.js
@@ -1,6 +1,6 @@
 import receipt from "receipt";
 import defaultReceiptConfig from "./config/receipt.js";
-import { preparedDataForPrintReceipt } from "./helpers/receiptData.js";
+import { prepareDataForPrintReceipt } from "./helpers/receiptData.js";
 import { initReceipt } from "./helpers/receipt.js";
 import getFiscalReceiptData from "./templateData/getFiscalReceiptData.js";
 import renderFiscalReceipt from "./templateBlocks/htmlFiscalReceipt.js";
@@ -9,7 +9,7 @@ import getXZReportData from "./templateData/getXZReportData.js";
 import renderXZReport from "./templateBlocks/htmlXZReport.js";
 
 const generateHtmlFiscalReceipt = (data) => {
-  const receiptData = preparedDataForPrintReceipt(data);
+  const receiptData = prepareDataForPrintReceipt(data);
   const fiscalReceiptData = getFiscalReceiptData(receiptData, true);
   return renderFiscalReceipt(fiscalReceiptData);
 };
@@ -24,7 +24,7 @@ const generateHtmlServiceTransactionReceipt = (data) => {
 
 const generateTextFiscalReceipt = (data) => {
   initReceipt(data.receiptConfig || defaultReceiptConfig);
-  const receiptData = preparedDataForPrintReceipt(data);
+  const receiptData = prepareDataForPrintReceipt(data);
   const fiscalReceiptData = getFiscalReceiptData(receiptData);
   return receipt.create(fiscalReceiptData);
 };
@@ -47,7 +47,7 @@ const generateHTMLXZReport = (data) => {
 };
 
 const getPreparedDataForPrintReceipt = (data) =>
-  preparedDataForPrintReceipt(data);
+  prepareDataForPrintReceipt(data);
 
 export {
   generateTextFiscalReceipt,

--- a/modules/receiptGenerator/templateBlocks/summaryBlock.js
+++ b/modules/receiptGenerator/templateBlocks/summaryBlock.js
@@ -1,10 +1,10 @@
 import { priceFormat } from "../helpers/receipt.js";
 
-const getSummaryBlock = ({ taxesData, roundData, currency }) => [
+const getSummaryBlock = ({ taxesAndPaymentsData, roundData, currency }) => [
   {
     type: "summary",
     lines: [
-      ...taxesBlock(taxesData, currency),
+      ...taxesAndPaymentsBlock(taxesAndPaymentsData, currency),
       ...(roundData ? getRoundData(roundData, currency) : []),
     ].filter(Boolean),
     delimeter: " ",
@@ -14,7 +14,7 @@ const getSummaryBlock = ({ taxesData, roundData, currency }) => [
   },
 ];
 
-const taxesBlock = (data, currency) =>
+const taxesAndPaymentsBlock = (data, currency) =>
   [
     {
       name: "Готівка",
@@ -34,7 +34,7 @@ const taxesBlock = (data, currency) =>
     { type: "ruler" },
     {
       name: "Сума",
-      value: `${priceFormat(data.total)} ${currency}`,
+      value: `${priceFormat(data.productsSum)} ${currency}`,
       bold: true,
     },
     ...data.taxes.map((tax) => ({

--- a/modules/receiptGenerator/templateBlocks/summaryBlock.js
+++ b/modules/receiptGenerator/templateBlocks/summaryBlock.js
@@ -1,10 +1,11 @@
 import { priceFormat } from "../helpers/receipt.js";
 
-const getSummaryBlock = ({ taxesAndPaymentsData, roundData, currency }) => [
+const getSummaryBlock = ({ paymentsData, taxesData, roundData, currency }) => [
   {
     type: "summary",
     lines: [
-      ...taxesAndPaymentsBlock(taxesAndPaymentsData, currency),
+      ...paymentsBlock(paymentsData, currency),
+      ...taxesBlock(taxesData),
       ...(roundData ? getRoundData(roundData, currency) : []),
     ].filter(Boolean),
     delimeter: " ",
@@ -14,7 +15,7 @@ const getSummaryBlock = ({ taxesAndPaymentsData, roundData, currency }) => [
   },
 ];
 
-const taxesAndPaymentsBlock = (data, currency) =>
+const paymentsBlock = (data, currency) =>
   [
     {
       name: "Готівка",
@@ -37,6 +38,10 @@ const taxesAndPaymentsBlock = (data, currency) =>
       value: `${priceFormat(data.productsSum)} ${currency}`,
       bold: true,
     },
+  ].filter(Boolean);
+
+const taxesBlock = (data) =>
+  [
     ...data.taxes.map((tax) => ({
       name: tax.name,
       value: priceFormat(tax.value),

--- a/modules/receiptGenerator/templateBlocks/summaryBlock.js
+++ b/modules/receiptGenerator/templateBlocks/summaryBlock.js
@@ -15,30 +15,29 @@ const getSummaryBlock = ({ paymentsData, taxesData, roundData, currency }) => [
   },
 ];
 
-const paymentsBlock = (data, currency) =>
-  [
-    {
-      name: "Готівка",
-      value: `${priceFormat(data.cash)} ${currency}`,
-      hidden: !data.cash,
-    },
-    {
-      name: "Безготівкова",
-      value: `${priceFormat(data.card)} ${currency}`,
-      hidden: !data.card,
-    },
-    {
-      name: "    Картка",
-      value: " ",
-      hidden: !data.card,
-    },
-    { type: "ruler" },
-    {
-      name: "Сума",
-      value: `${priceFormat(data.productsSum)} ${currency}`,
-      bold: true,
-    },
-  ].filter(Boolean);
+const paymentsBlock = (data, currency) => [
+  {
+    name: "Готівка",
+    value: `${priceFormat(data.cash)} ${currency}`,
+    hidden: !data.cash,
+  },
+  {
+    name: "Безготівкова",
+    value: `${priceFormat(data.card)} ${currency}`,
+    hidden: !data.card,
+  },
+  {
+    name: "    Картка",
+    value: " ",
+    hidden: !data.card,
+  },
+  { type: "ruler" },
+  {
+    name: "Сума",
+    value: `${priceFormat(data.productsSum)} ${currency}`,
+    bold: true,
+  },
+];
 
 const taxesBlock = (data) =>
   [

--- a/modules/receiptGenerator/templateData/getFiscalReceiptData.js
+++ b/modules/receiptGenerator/templateData/getFiscalReceiptData.js
@@ -20,7 +20,7 @@ const productsData = (data) => getProductsData(data.productsData);
 
 const summaryData = (data) =>
   getSummaryBlock({
-    taxesData: data.taxesData,
+    taxesAndPaymentsData: data.taxesAndPaymentsData,
     roundData: data.roundData,
     currency: data.receiptConfig?.currency || defaultReceiptConfig.currency,
   });

--- a/modules/receiptGenerator/templateData/getFiscalReceiptData.js
+++ b/modules/receiptGenerator/templateData/getFiscalReceiptData.js
@@ -20,7 +20,8 @@ const productsData = (data) => getProductsData(data.productsData);
 
 const summaryData = (data) =>
   getSummaryBlock({
-    taxesAndPaymentsData: data.taxesAndPaymentsData,
+    paymentsData: data.paymentsData,
+    taxesData: data.taxesData,
     roundData: data.roundData,
     currency: data.receiptConfig?.currency || defaultReceiptConfig.currency,
   });

--- a/modules/receiptGenerator/templateData/getXZReportData.js
+++ b/modules/receiptGenerator/templateData/getXZReportData.js
@@ -170,75 +170,69 @@ const xzReportRealizeData = (data) => [
       },
       ...(data?.realiz?.payments
         ? [
-          hasCashPayment(data?.realiz?.payments)
-            ? {
-              row: ["Готівка", getCashPaymentSum(data?.realiz?.payments)],
+            hasCashPayment(data?.realiz?.payments)
+              ? {
+                  row: ["Готівка", getCashPaymentSum(data?.realiz?.payments)],
+                  styles: {
+                    0: { extraCssClass: "w-50 pt-0 pb-0" },
+                    1: { extraCssClass: "text-end pt-0 pb-0" },
+                  },
+                }
+              : null,
+            hasCardPayment(data?.realiz?.payments)
+              ? {
+                  row: [
+                    "Безготівкова",
+                    getCardPaymentSum(data?.realiz?.payments),
+                  ],
+                  styles: {
+                    0: { extraCssClass: "w-50 pt-0 pb-0" },
+                    1: { extraCssClass: "text-end pt-0 pb-0" },
+                  },
+                }
+              : null,
+            hasCardPayment(data?.realiz?.payments)
+              ? {
+                  row: ["Картка", " "],
+                  styles: {
+                    0: { extraCssClass: "pt-0 pb-0" },
+                    1: { extraCssClass: "pt-0 pb-0" },
+                  },
+                }
+              : null,
+            {
+              row: ["", ""],
               styles: {
-                0: { extraCssClass: "w-50 pt-0 pb-0" },
-                1: { extraCssClass: "text-end pt-0 pb-0" },
+                0: { extraCssClass: "pt-3 pb-0" },
+                1: { extraCssClass: "pt-3 pb-0" },
               },
-            }
-            : null,
-          hasCardPayment(data?.realiz?.payments)
-            ? {
-              row: [
-                "Безготівкова",
-                getCardPaymentSum(data?.realiz?.payments),
-              ],
-              styles: {
-                0: { extraCssClass: "w-50 pt-0 pb-0" },
-                1: { extraCssClass: "text-end pt-0 pb-0" },
-              },
-            }
-            : null,
-          hasCardPayment(data?.realiz?.payments)
-            ? {
-              row: ["Картка", " "],
-              styles: {
-                0: { extraCssClass: "pt-0 pb-0" },
-                1: { extraCssClass: "pt-0 pb-0" },
-              },
-            }
-            : null,
-          {
-            row: ["", ""],
-            styles: {
-              0: { extraCssClass: "pt-3 pb-0" },
-              1: { extraCssClass: "pt-3 pb-0" },
             },
-          },
-          {
-            row: ["Кількість чеків", data?.realiz?.receiptCount || "0"],
-            styles: {
-              0: { extraCssClass: "w-50 pt-0 pb-0" },
-              1: { extraCssClass: "text-end pt-0 pb-0" },
+            {
+              row: ["Кількість чеків", data?.realiz?.receiptCount || "0"],
+              styles: {
+                0: { extraCssClass: "w-50 pt-0 pb-0" },
+                1: { extraCssClass: "text-end pt-0 pb-0" },
+              },
             },
-          },
-          getCashPaymentCount(data?.realiz?.payments)
-            ? {
-              row: [
-                "Готівка",
-                getCashPaymentCount(data?.realiz?.payments),
-              ],
-              styles: {
-                0: { extraCssClass: "w-50 pt-0 pb-0" },
-                1: { extraCssClass: "text-end pt-0 pb-0" },
-              },
-            }
-            : null,
-          getCardPaymentCount(data?.realiz?.payments)
-            ? {
-              row: [
-                "Картка",
-                getCardPaymentCount(data?.realiz?.payments),
-              ],
-              styles: {
-                0: { extraCssClass: "w-50 pt-0 pb-0" },
-                1: { extraCssClass: "text-end pt-0 pb-0" },
-              },
-            }
-            : null,
-        ]
+            getCashPaymentCount(data?.realiz?.payments)
+              ? {
+                  row: ["Готівка", getCashPaymentCount(data?.realiz?.payments)],
+                  styles: {
+                    0: { extraCssClass: "w-50 pt-0 pb-0" },
+                    1: { extraCssClass: "text-end pt-0 pb-0" },
+                  },
+                }
+              : null,
+            getCardPaymentCount(data?.realiz?.payments)
+              ? {
+                  row: ["Картка", getCardPaymentCount(data?.realiz?.payments)],
+                  styles: {
+                    0: { extraCssClass: "w-50 pt-0 pb-0" },
+                    1: { extraCssClass: "text-end pt-0 pb-0" },
+                  },
+                }
+              : null,
+          ]
         : [null]),
     ].filter(Boolean),
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "poster-prro-kit",
-  "version": "0.0.163",
+  "version": "0.0.167",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "poster-prro-kit",
-      "version": "0.0.163",
+      "version": "0.0.167",
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poster-prro-kit",
-  "version": "0.0.166",
+  "version": "0.0.167",
   "main": "index.js",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
**Refactoring:**
-  переіменували `getTaxesData` на `getTaxesAndPaymentsData`  - бо це не тільки taxes data там ще є дані по payments
- додали поле `productsSum` в`getTaxesAndPaymentsData` до цього було поле `total`, але воно не повинно було  мати заокруглення і тому це вже було не зовсім тотал, а це  як раз сума всіх товарів, яку ми і вираховуємо зараз через продукти
- поправив відступи для lint-а в `modules/receiptGenerator/templateData/getXZReportData.js`
